### PR TITLE
fix: replace inline scripts in user data with stub to stay under 16 K…

### DIFF
--- a/iac/aws/modules/shared-core-compute/main.tf
+++ b/iac/aws/modules/shared-core-compute/main.tf
@@ -32,7 +32,8 @@ resource "aws_instance" "shared_core_host" {
   associate_public_ip_address = true
   vpc_security_group_ids      = [local.shared_core_security_group_id]
   iam_instance_profile        = var.common_ec2_iam_instance_profile_name
-  user_data_base64 = base64encode(templatefile("${path.module}/templates/install-scripts.sh.tpl", {})) # Prevent instance replacement when scripts are updated — deploy script changes via SSH/SSM instead
+  # Prevent instance replacement when scripts are updated — deploy script changes via SSH/SSM instead
+  user_data_base64            = base64encode(templatefile("${path.module}/templates/install-scripts.sh.tpl", {}))
   user_data_replace_on_change = false
   root_block_device {
     volume_size           = 80

--- a/iac/aws/modules/shared-core-compute/main.tf
+++ b/iac/aws/modules/shared-core-compute/main.tf
@@ -32,10 +32,7 @@ resource "aws_instance" "shared_core_host" {
   associate_public_ip_address = true
   vpc_security_group_ids      = [local.shared_core_security_group_id]
   iam_instance_profile        = var.common_ec2_iam_instance_profile_name
-  user_data_base64 = base64encode(templatefile("${path.module}/templates/install-scripts.sh.tpl", {
-    provision_script   = file("${path.module}/scripts/provision-student.sh")
-    deprovision_script = file("${path.module}/scripts/deprovision-student.sh")
-  })) # Prevent instance replacement when scripts are updated — deploy script changes via SSM instead
+  user_data_base64 = base64encode(templatefile("${path.module}/templates/install-scripts.sh.tpl", {})) # Prevent instance replacement when scripts are updated — deploy script changes via SSH/SSM instead
   user_data_replace_on_change = false
   root_block_device {
     volume_size           = 80

--- a/iac/aws/modules/shared-core-compute/templates/install-scripts.sh.tpl
+++ b/iac/aws/modules/shared-core-compute/templates/install-scripts.sh.tpl
@@ -1,15 +1,21 @@
 #!/bin/bash
-# Install shared-core provisioning scripts on instance startup.
-# These scripts are called via SSM Run Command by the shared_core_provisioner Lambda.
-
+# Minimal bootstrap: create the scripts directory so the shared_core_provisioner
+# Lambda can invoke scripts via SSM Run Command as soon as the instance registers.
+# The actual script content is deployed by the deploy-shared-core workflow (git pull
+# + SSH copy) to keep user data well under the 16 KB EC2 limit.
 mkdir -p /opt/scripts
 
-cat > /opt/scripts/provision-student.sh << 'PROVISION_EOF'
-${provision_script}
-PROVISION_EOF
+# Placeholder stubs — replaced by the deploy-shared-core workflow on first deploy.
+cat > /opt/scripts/provision-student.sh << 'EOF'
+#!/bin/bash
+echo "[provision] Script not yet deployed. Run the deploy-shared-core workflow to install scripts." >&2
+exit 1
+EOF
 
-cat > /opt/scripts/deprovision-student.sh << 'DEPROVISION_EOF'
-${deprovision_script}
-DEPROVISION_EOF
+cat > /opt/scripts/deprovision-student.sh << 'EOF'
+#!/bin/bash
+echo "[deprovision] Script not yet deployed. Run the deploy-shared-core workflow to install scripts." >&2
+exit 1
+EOF
 
 chmod +x /opt/scripts/provision-student.sh /opt/scripts/deprovision-student.sh


### PR DESCRIPTION
…B EC2 limit

The provision-student.sh (13.8 KB) + deprovision-student.sh (3.9 KB) exceed the 16384-byte EC2 user data limit when templated inline. Replace with a minimal stub that only creates /opt/scripts and placeholder scripts. Real scripts are deployed by the deploy-shared-core workflow (git pull + copy) which is already how updates were handled (user_data_replace_on_change=false).